### PR TITLE
Add ok-to-truthy codemod

### DIFF
--- a/lib/ok-to-truthy.js
+++ b/lib/ok-to-truthy.js
@@ -3,7 +3,7 @@ var utils = require('./utils');
 module.exports = function transformer(file, api) {
 	var j = api.jscodeshift;
 	var ast = j(file.source);
-	utils.renameAssertion('same', 'deepEqual', j, ast);
-	utils.renameAssertion('notSame', 'notDeepEqual', j, ast);
+	utils.renameAssertion('ok', 'truthy', j, ast);
+	utils.renameAssertion('notOk', 'falsy', j, ast);
 	return ast.toSource();
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,21 @@
+function renameAssertion(name, newName, j, ast) {
+	ast.find(j.CallExpression, {
+		callee: {
+			object: {name: 't'},
+			property: {name: name}
+		}
+	})
+		.replaceWith(function (p) {
+			return j.callExpression(
+				j.memberExpression(
+					j.identifier('t'),
+					j.identifier(newName)
+				),
+				p.node.arguments
+			);
+		});
+}
+
+module.exports = {
+	renameAssertion: renameAssertion
+};

--- a/test/ok-to-truthy.js
+++ b/test/ok-to-truthy.js
@@ -1,0 +1,12 @@
+import ava from 'ava';
+import {wrapPlugin} from './_helpers';
+import plugin from '../lib/ok-to-truthy';
+
+const wrapped = wrapPlugin(plugin);
+
+function test(input, expected) {
+	ava(input, t => t.is(wrapped(input), expected));
+}
+
+test('t.ok(foo, bar)', 't.truthy(foo, bar)');
+test('t.notOk(foo, bar)', 't.falsy(foo, bar)');


### PR DESCRIPTION
Add ok-to-truthy codemod, related to https://github.com/sindresorhus/ava/pull/663
- `t.ok(...)` --> `t.truthy(...)`
- `t.notOk(...)` --> `t.falsy(...)`
