### PR TITLE
Add CLI to help select/run codemods

### DIFF
--- a/cli-utils.js
+++ b/cli-utils.js
@@ -1,0 +1,44 @@
+var semver = require('semver');
+var uniq = require('lodash.uniq');
+var flatten = require('lodash.flatten');
+
+function sortByVersion(a, b) {
+	if (a.version === b.version) {
+		return 0;
+	}
+	return semver.lt(a.version, b.version) ? -1 : +1;
+}
+
+function getVersions(codemods) {
+	var versionsFromCodemods = codemods.sort(sortByVersion).map(function (codemod) {
+		return codemod.version;
+	});
+	var uniqueVersions = uniq(versionsFromCodemods);
+	var firstVersion = {
+		name: 'older than ' + uniqueVersions.sort(sortByVersion)[0],
+		value: '0.0.0'
+	};
+	var lastVersion = {
+		name: 'latest',
+		value: '9999.9999.9999'
+	};
+	return [firstVersion].concat(versionsFromCodemods).concat(lastVersion);
+}
+
+function selectScripts(codemods, currentVersion, nextVersion) {
+	var semverToRespect = '>' + currentVersion + ' <=' + nextVersion;
+
+	var scripts = codemods.filter(function (codemod) {
+		return semver.satisfies(codemod.version, semverToRespect);
+	}).map(function (codemod) {
+		return codemod.scripts;
+	});
+
+	return flatten(scripts);
+}
+
+module.exports = {
+	sortByVersion: sortByVersion,
+	getVersions: getVersions,
+	selectScripts: selectScripts
+};

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,51 @@
+var path = require('path');
+var childProcess = require('child_process');
+var inquirer = require('inquirer');
+var assign = require('lodash.assign');
+var utils = require('./cli-utils');
+var codemods = require('./codemods.json');
+
+function runScripts(scripts, files) {
+	var spawnOptions = {
+		env: assign({}, process.env, {PATH: path.resolve('node_modules/.bin') + ':' + process.env.PATH})
+	};
+
+	var result;
+	scripts.forEach(function (script) {
+		result = childProcess.spawnSync('jscodeshift', ['-t', script].concat(files.split(' ')), spawnOptions);
+		if (result.error) {
+			throw result.error;
+		}
+	});
+}
+
+codemods.sort(utils.sortByVersion);
+
+var versions = utils.getVersions(codemods);
+
+var questions = [{
+	type: 'list',
+	name: 'currentVersion',
+	message: 'What version of AVA are you currently using?',
+	choices: versions.slice(0, -1)
+}, {
+	type: 'list',
+	name: 'nextVersion',
+	message: 'What version of AVA are you moving to?',
+	choices: versions.slice(1)
+}, {
+	type: 'input',
+	name: 'files',
+	message: 'On which files should the codemods be applied?'
+}];
+
+inquirer.prompt(questions, function (answers) {
+	console.log(answers.files);
+	if (!answers.files) {
+		return;
+	}
+
+	var scripts = utils.selectScripts(codemods, answers.currentVersion, answers.nextVersion);
+
+	runScripts(scripts, answers.files);
+});

--- a/codemods.json
+++ b/codemods.json
@@ -1,0 +1,9 @@
+[
+	{
+		"version": "0.14.0",
+		"scripts": [
+			"lib/ok-to-truthy.js",
+			"lib/same-to-deep-equal.js"
+		]
+	}
+]

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
     "ava"
   ],
   "dependencies": {
-    "jscodeshift": "^0.3.19"
+    "inquirer": "^0.12.0",
+    "jscodeshift": "^0.3.19",
+    "lodash.assign": "^4.0.7",
+    "lodash.flatten": "^4.1.1",
+    "lodash.uniq": "^4.2.1"
   },
   "devDependencies": {
     "ava": "^0.13.0",

--- a/test/cli-utils.js
+++ b/test/cli-utils.js
@@ -1,0 +1,94 @@
+import test from 'ava';
+import {sortByVersion, getVersions, selectScripts} from '../cli-utils';
+
+test('sortByVersion', t => {
+	const array = [
+		{version: '1.0.1'},
+		{version: '88.0.1'},
+		{version: '0.0.1'},
+		{version: '1.0.0'},
+		{version: '1.10.0'},
+		{version: '1.2.0'}
+	];
+
+	t.same(array.sort(sortByVersion), [
+		{version: '0.0.1'},
+		{version: '1.0.0'},
+		{version: '1.0.1'},
+		{version: '1.2.0'},
+		{version: '1.10.0'},
+		{version: '88.0.1'}
+	]);
+});
+
+test('getVersions', t => {
+	const array = [
+		{version: '1.0.1'},
+		{version: '88.0.1'},
+		{version: '0.0.1'},
+		{version: '1.0.0'},
+		{version: '1.10.0'},
+		{version: '1.2.0'}
+	];
+
+	t.same(getVersions(array), [{
+		name: 'older than 0.0.1',
+		value: '0.0.0'
+	},
+	'0.0.1',
+	'1.0.0',
+	'1.0.1',
+	'1.2.0',
+	'1.10.0',
+	'88.0.1',
+	{
+		name: 'latest',
+		value: '9999.9999.9999'
+	}]);
+});
+
+test('selectScripts', t => {
+	var codemods = [{
+		version: '0.14.0',
+		scripts: [
+			'lib/ok-to-truthy.js',
+			'lib/same-to-deep-equal.js'
+		]
+	}, {
+		version: '0.15.0',
+		scripts: [
+			'lib/script-0.15.0.js'
+		]
+	}, {
+		version: '1.0.0',
+		scripts: [
+			'lib/script-1.0.0.js'
+		]
+	}, {
+		version: '2.0.0',
+		scripts: [
+			'lib/script-2.0.0.js'
+		]
+	}];
+
+	t.same(selectScripts(codemods, '0.14.0', '0.14.0'), []);
+
+	t.same(selectScripts(codemods, '0.14.0', '1.0.0'), [
+		'lib/script-0.15.0.js',
+		'lib/script-1.0.0.js'
+	]);
+
+	t.same(selectScripts(codemods, '0.0.0', '0.15.0'), [
+		'lib/ok-to-truthy.js',
+		'lib/same-to-deep-equal.js',
+		'lib/script-0.15.0.js'
+	]);
+
+	t.same(selectScripts(codemods, '0.0.0', '9999.9999.9999'), [
+		'lib/ok-to-truthy.js',
+		'lib/same-to-deep-equal.js',
+		'lib/script-0.15.0.js',
+		'lib/script-1.0.0.js',
+		'lib/script-2.0.0.js'
+	]);
+});


### PR DESCRIPTION
I've added a CLI tool to help move from a version of AVA to another.
It kind of looks like this:

![image](https://cloud.githubusercontent.com/assets/3869412/14298459/50cab8d2-fb85-11e5-9b1b-b51d88a1ae3a.png)

I've created a file `codemods.json` which should list the versions that contain codemod-able changes. For now, there is only one entry for v0.14, which is the codemods needed to go from <0.14.0 to 0.14.0. Hopefully, we will later only have create the codemods and modify that file.

We could later have a different question for selecting upgrade codemods (0.13 --> 0.14) or transition codemods (mocha --> ava).

Pretty sure this will not when installed globally (it needs to find `jscodeshift` in the $PATH), would welcome some tips.
