### PR TITLE
Add CLI to help select/run codemods

### DIFF
--- a/cli-utils.js
+++ b/cli-utils.js
@@ -1,0 +1,47 @@
+var path = require('path');
+var semver = require('semver');
+var uniq = require('lodash.uniq');
+var flatten = require('lodash.flatten');
+
+function sortByVersion(a, b) {
+	if (a.version === b.version) {
+		return 0;
+	}
+	return semver.lt(a.version, b.version) ? -1 : +1;
+}
+
+function getVersions(codemods) {
+	var versionsFromCodemods = codemods.sort(sortByVersion).map(function (codemod) {
+		return codemod.version;
+	});
+	var uniqueVersions = uniq(versionsFromCodemods);
+	var firstVersion = {
+		name: 'older than ' + uniqueVersions.sort(sortByVersion)[0],
+		value: '0.0.0'
+	};
+	var lastVersion = {
+		name: 'latest',
+		value: '9999.9999.9999'
+	};
+	return [firstVersion].concat(versionsFromCodemods).concat(lastVersion);
+}
+
+function selectScripts(codemods, currentVersion, nextVersion) {
+	var semverToRespect = '>' + currentVersion + ' <=' + nextVersion;
+
+	var scripts = codemods.filter(function (codemod) {
+		return semver.satisfies(codemod.version, semverToRespect);
+	}).map(function (codemod) {
+		return codemod.scripts;
+	});
+
+	return flatten(scripts).map(function (script) {
+		return path.join(__dirname, script);
+	});
+}
+
+module.exports = {
+	sortByVersion: sortByVersion,
+	getVersions: getVersions,
+	selectScripts: selectScripts
+};

--- a/cli.js
+++ b/cli.js
@@ -11,7 +11,6 @@ var utils = require('./cli-utils');
 var codemods = require('./codemods.json');
 
 function runScripts(scripts, files) {
-	// var binPath = require.resolve('jscodeshift/bin/jscodeshift.sh');
 	var spawnOptions = {
 		env: assign({}, process.env, {PATH: npmRunPath()}),
 		stdio: 'inherit'
@@ -30,10 +29,8 @@ meow(`
 		Usage
 			$ ava-codemods
 
-		Ensure you have a backup of your tests or commit the latest changes before running this.
-
-		Upgrades available:
-			- 0.13.x to 0.14.x
+		Available upgrades
+			- 0.13.x → 0.14.x
 `);
 
 codemods.sort(utils.sortByVersion);

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+'use strict';
+
+var path = require('path');
+var childProcess = require('child_process');
+var globby = require('globby');
+var inquirer = require('inquirer');
+var assign = require('lodash.assign');
+var utils = require('./cli-utils');
+var codemods = require('./codemods.json');
+
+function runScripts(scripts, files) {
+	var binPath = require.resolve('jscodeshift/bin/jscodeshift.sh');
+	var spawnOptions = {
+		env: assign({}, process.env, {PATH: path.resolve('node_modules/.bin') + ':' + process.env.PATH}),
+		stdio: 'inherit'
+	};
+
+	var result;
+	scripts.forEach(function (script) {
+		result = childProcess.spawnSync(binPath, ['-t', script].concat(files.split(' ')), spawnOptions);
+		if (result.error) {
+			throw result.error;
+		}
+	});
+}
+
+codemods.sort(utils.sortByVersion);
+
+var versions = utils.getVersions(codemods);
+
+var questions = [{
+	type: 'list',
+	name: 'currentVersion',
+	message: 'What version of AVA are you currently using?',
+	choices: versions.slice(0, -1)
+}, {
+	type: 'list',
+	name: 'nextVersion',
+	message: 'What version of AVA are you moving to?',
+	choices: versions.slice(1)
+}, {
+	type: 'input',
+	name: 'files',
+	message: 'On which files should the codemods be applied?'
+}];
+
+inquirer.prompt(questions, function (answers) {
+	if (!answers.files) {
+		return;
+	}
+
+	var scripts = utils.selectScripts(codemods, answers.currentVersion, answers.nextVersion);
+
+	runScripts(scripts, globby.sync(answers.files.split(/\s+/)));
+});

--- a/codemods.json
+++ b/codemods.json
@@ -1,0 +1,9 @@
+[
+	{
+		"version": "0.14.0",
+		"scripts": [
+			"lib/ok-to-truthy.js",
+			"lib/same-to-deep-equal.js"
+		]
+	}
+]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ava-codemods",
   "version": "0.0.1",
-  "description": "My bedazzling module",
+  "description": "Codemods to simplify upgrading AVA versions",
   "license": "MIT",
   "repository": "jamestalmage/ava-codemods",
   "author": {
@@ -33,6 +33,8 @@
     "lodash.assign": "^4.0.7",
     "lodash.flatten": "^4.1.1",
     "lodash.uniq": "^4.2.1",
+    "meow": "^3.7.0",
+    "npm-run-path": "^1.0.0",
     "semver": "^5.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "email": "james@talmage.io",
     "url": "github.com/jamestalmage"
   },
+  "bin": "cli.js",
   "engines": {
     "node": ">=0.10.0"
   },
@@ -16,14 +17,23 @@
     "test": "xo && ava"
   },
   "files": [
-    "index.js"
+    "cli.js",
+    "cli-utils.js",
+    "codemods.json",
+    "lib"
   ],
   "keywords": [
     "codemod",
     "ava"
   ],
   "dependencies": {
-    "jscodeshift": "^0.3.19"
+    "globby": "^4.0.0",
+    "inquirer": "^0.12.0",
+    "jscodeshift": "^0.3.19",
+    "lodash.assign": "^4.0.7",
+    "lodash.flatten": "^4.1.1",
+    "lodash.uniq": "^4.2.1",
+    "semver": "^5.1.0"
   },
   "devDependencies": {
     "ava": "^0.13.0",

--- a/readme.md
+++ b/readme.md
@@ -2,44 +2,27 @@
 
 > Codemods for AVA
 
-Status is pre-alpha. Recommended only for exploratory use.
+Codemods to simplify upgrading [AVA](https://github.com/sindresorhus/ava) versions.
 
 ## Install
 
 ```
-$ npm install --save ava-codemods
+$ npm install --global ava-codemods
 ```
 
 
 ## Usage
 
-```js
-const avaCodemods = require('ava-codemods');
+Simply run `ava-codemods` in your terminal and answer a few questions.
 
-avaCodemods('unicorns');
-//=> 'unicorns & rainbows'
-```
+## Supported codemods
 
+### Upgrading to 0.14
 
-## API
-
-### avaCodemods(input, [options])
-
-#### input
-
-Type: `string`
-
-Lorem ipsum.
-
-#### options
-
-##### foo
-
-Type: `boolean`<br>
-Default: `false`
-
-Lorem ipsum.
-
+- Renaming `t.ok()` to `t.truthy()`
+- Renaming `t.notOk()` to `t.falsy()`
+- Renaming `t.same()` to `t.deepEqual()`
+- Renaming `t.notSame()` to `t.notDeepEqual()`
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ $ npm install --global ava-codemods
 ## Usage
 
 Simply run `ava-codemods` in your terminal and answer a few questions.
+Ensure you have a backup of your tests or commit the latest changes before running this.
 
 ## Supported codemods
 

--- a/test/cli-utils.js
+++ b/test/cli-utils.js
@@ -1,0 +1,101 @@
+import path from 'path';
+import test from 'ava';
+import {sortByVersion, getVersions, selectScripts} from '../cli-utils';
+
+function resolve(files) {
+	return files.map(function (file) {
+		return path.resolve(__dirname, '..', file);
+	});
+}
+
+test('sortByVersion', t => {
+	const array = [
+		{version: '1.0.1'},
+		{version: '88.0.1'},
+		{version: '0.0.1'},
+		{version: '1.0.0'},
+		{version: '1.10.0'},
+		{version: '1.2.0'}
+	];
+
+	t.same(array.sort(sortByVersion), [
+		{version: '0.0.1'},
+		{version: '1.0.0'},
+		{version: '1.0.1'},
+		{version: '1.2.0'},
+		{version: '1.10.0'},
+		{version: '88.0.1'}
+	]);
+});
+
+test('getVersions', t => {
+	const array = [
+		{version: '1.0.1'},
+		{version: '88.0.1'},
+		{version: '0.0.1'},
+		{version: '1.0.0'},
+		{version: '1.10.0'},
+		{version: '1.2.0'}
+	];
+
+	t.same(getVersions(array), [{
+		name: 'older than 0.0.1',
+		value: '0.0.0'
+	},
+	'0.0.1',
+	'1.0.0',
+	'1.0.1',
+	'1.2.0',
+	'1.10.0',
+	'88.0.1',
+	{
+		name: 'latest',
+		value: '9999.9999.9999'
+	}]);
+});
+
+test('selectScripts', t => {
+	var codemods = [{
+		version: '0.14.0',
+		scripts: [
+			'lib/ok-to-truthy.js',
+			'lib/same-to-deep-equal.js'
+		]
+	}, {
+		version: '0.15.0',
+		scripts: [
+			'lib/script-0.15.0.js'
+		]
+	}, {
+		version: '1.0.0',
+		scripts: [
+			'lib/script-1.0.0.js'
+		]
+	}, {
+		version: '2.0.0',
+		scripts: [
+			'lib/script-2.0.0.js'
+		]
+	}];
+
+	t.same(selectScripts(codemods, '0.14.0', '0.14.0'), []);
+
+	t.same(selectScripts(codemods, '0.14.0', '1.0.0'), resolve([
+		'lib/script-0.15.0.js',
+		'lib/script-1.0.0.js'
+	]));
+
+	t.same(selectScripts(codemods, '0.0.0', '0.15.0'), resolve([
+		'lib/ok-to-truthy.js',
+		'lib/same-to-deep-equal.js',
+		'lib/script-0.15.0.js'
+	]));
+
+	t.same(selectScripts(codemods, '0.0.0', '9999.9999.9999'), resolve([
+		'lib/ok-to-truthy.js',
+		'lib/same-to-deep-equal.js',
+		'lib/script-0.15.0.js',
+		'lib/script-1.0.0.js',
+		'lib/script-2.0.0.js'
+	]));
+});


### PR DESCRIPTION
I've added a CLI tool to help move from a version of AVA to another.
It kind of looks like this:

![image](https://cloud.githubusercontent.com/assets/3869412/14298459/50cab8d2-fb85-11e5-9b1b-b51d88a1ae3a.png)

I've created a file `codemods.json` which should list the versions that contain codemod-able changes. For now, there is only one entry for v0.14, which is the codemods needed to go from <0.14.0 to 0.14.0. Hopefully, we will later only have create the codemods and modify that file.

We could later have a different question for selecting upgrade codemods (0.13 --> 0.14) or transition codemods (mocha --> ava).

Pretty sure this will not when installed globally (it needs to find `jscodeshift` in the $PATH), would welcome some tips.
