### PR TITLE
Add default path

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -4,7 +4,9 @@ global.Promise = require('pinkie-promise');
 var childProcess = require('child_process');
 var meow = require('meow');
 var updateNotifier = require('update-notifier');
+var arrify = require('arrify');
 var globby = require('globby');
+var pkgConf = require('pkg-conf');
 var inquirer = require('inquirer');
 var assign = require('lodash.assign');
 var npmRunPath = require('npm-run-path');
@@ -75,6 +77,9 @@ codemods.sort(utils.sortByVersion);
 
 var versions = utils.getVersions(codemods);
 
+var avaConf = pkgConf.sync('ava');
+var defaultFiles = 'test.js test-*.js test/**/*.js';
+
 var questions = [{
 	type: 'list',
 	name: 'currentVersion',
@@ -89,6 +94,7 @@ var questions = [{
 	type: 'input',
 	name: 'files',
 	message: 'On which files should the codemods be applied?',
+	default: (avaConf.files && arrify(avaConf.files).join(' ')) || defaultFiles,
 	when: !cli.input.length,
 	filter: function (files) {
 		return files.trim().split(/\s+/).filter(function (v) {

--- a/cli.js
+++ b/cli.js
@@ -91,7 +91,9 @@ var questions = [{
 	message: 'On which files should the codemods be applied?',
 	when: !cli.input.length,
 	filter: function (files) {
-		return files.trim().split(/\s+/);
+		return files.trim().split(/\s+/).filter(function (v) {
+			return v;
+		});
 	}
 }];
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "transform"
   ],
   "dependencies": {
+    "arrify": "^1.0.1",
     "globby": "^4.0.0",
     "inquirer": "^0.12.0",
     "is-git-clean": "^1.0.0",
@@ -41,6 +42,7 @@
     "meow": "^3.7.0",
     "npm-run-path": "^1.0.0",
     "pinkie-promise": "^2.0.0",
+    "pkg-conf": "^1.1.2",
     "semver": "^5.1.0",
     "update-notifier": "^0.6.3"
   },


### PR DESCRIPTION
- Fix error when specifying no path.
  When pressing enter for the `files` question, the value of `answer.files` is `['']`, which passes the `files.length` condition.
- Check the `package.json` for AVA config to get the `files` path and use it as the default path. Use AVA's default otherwise.
