### PR TITLE
Fix broken build badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# ava-codemods [![Build Status](https://travis-ci.org/jamestalmage/ava-codemods.svg?branch=master)](https://travis-ci.org/jamestalmage/ava-codemods)
+# ava-codemods [![Build Status](https://travis-ci.org/avajs/ava-codemods.svg?branch=master)](https://travis-ci.org/avajs/ava-codemods)
 
 > Codemods for [AVA](https://ava.li) that simplifies upgrading to newer versions
 


### PR DESCRIPTION
A tiny fix to get the correct build badge from travis.

Before:
![screen shot 2016-05-18 at 3 20 04 pm](https://cloud.githubusercontent.com/assets/3477707/15376797/28f60692-1d0c-11e6-860a-96c575045710.png)

After:
![screen shot 2016-05-18 at 3 20 30 pm](https://cloud.githubusercontent.com/assets/3477707/15376801/2cd9cb90-1d0c-11e6-8fa6-a4a6413b06f5.png)
