### PR TITLE
Add transform from Tape to AVA

### DIFF
--- a/cli-utils.js
+++ b/cli-utils.js
@@ -2,6 +2,7 @@ const path = require('path');
 const semver = require('semver');
 const uniq = require('lodash.uniq');
 const flatten = require('lodash.flatten');
+const isGitClean = require('is-git-clean');
 
 export function sortByVersion(a, b) {
 	if (a.version === b.version) {
@@ -34,4 +35,30 @@ export function selectScripts(codemods, currentVersion, nextVersion) {
 	.map(codemod => codemod.scripts);
 
 	return flatten(scripts).map(script => path.join(__dirname, script));
+}
+
+export function checkGitStatus(force) {
+	let clean = false;
+	let errorMessage = 'Unable to determine if git directory is clean';
+	try {
+		clean = isGitClean.sync(process.cwd(), {files: ['!package.json']});
+		errorMessage = 'Git directory is not clean';
+	} catch (err) {}
+
+	const ENSURE_BACKUP_MESSAGE = 'Ensure you have a backup of your tests or commit the latest changes before continuing.';
+
+	if (!clean) {
+		if (force) {
+			console.log(`WARNING: ${errorMessage}. Forcibly continuing.`, ENSURE_BACKUP_MESSAGE);
+		} else {
+			console.log(
+				`ERROR: ${errorMessage}. Refusing to continue.`,
+				ENSURE_BACKUP_MESSAGE,
+				'You may use the --force flag to override this safety check.'
+			);
+			return false;
+		}
+	}
+
+	return true;
 }

--- a/lib/tape.js
+++ b/lib/tape.js
@@ -1,0 +1,304 @@
+/**
+ * Codemod for transforming Tape tests into AVA.
+ */
+
+const tapeToAvaAsserts = {
+	fail: 'fail',
+	pass: 'pass',
+
+	ok: 'truthy',
+	true: 'truthy',
+	assert: 'truthy',
+
+	notOk: 'falsy',
+	false: 'falsy',
+	notok: 'falsy',
+
+	error: 'ifError',
+	ifErr: 'ifError',
+	iferror: 'ifError',
+
+	equal: 'is',
+	equals: 'is',
+	isEqual: 'is',
+	strictEqual: 'is',
+	strictEquals: 'is',
+
+	notEqual: 'not',
+	notStrictEqual: 'not',
+	notStrictEquals: 'not',
+	isNotEqual: 'not',
+	doesNotEqual: 'not',
+	isInequal: 'not',
+
+	deepEqual: 'deepEqual',
+	isEquivalent: 'deepEqual',
+	same: 'deepEqual',
+
+	notDeepEqual: 'notDeepEqual',
+	notEquivalent: 'notDeepEqual',
+	notDeeply: 'notDeepEqual',
+	notSame: 'notDeepEqual',
+	isNotDeepEqual: 'notDeepEqual',
+	isNotEquivalent: 'notDeepEqual',
+	isInequivalent: 'notDeepEqual',
+
+	skip: 'skip',
+	throws: 'throws',
+	doesNotThrow: 'notThrows'
+};
+
+const unsupportedTestFunctions = new Set([
+	// No equivalent in AVA:
+	'timeoutAfter',
+
+	// t.deepEqual is more strict but might be used in some cases:
+	'deepLooseEqual',
+	'looseEqual',
+	'looseEquals',
+	'notDeepLooseEqual',
+	'notLooseEqual',
+	'notLooseEquals'
+]);
+
+function detectQuoteStyle(j, ast) {
+	let detectedQuoting = null;
+
+	ast.find(j.Literal, {
+		value: v => typeof v === 'string',
+		raw: v => typeof v === 'string'
+	})
+	.forEach(p => {
+		// The raw value is from the original babel source
+		if (p.value.raw[0] === '\'') {
+			detectedQuoting = 'single';
+		}
+
+		if (p.value.raw[0] === '"') {
+			detectedQuoting = 'double';
+		}
+	});
+
+	return detectedQuoting;
+}
+
+/**
+ * Updates CommonJS and import statements from Tape to AVA
+ * @return string with test function name if transformations were made
+ */
+function updateTapeRequireAndImport(j, ast) {
+	let testFunctionName = null;
+	ast.find(j.CallExpression, {
+		callee: {name: 'require'},
+		arguments: arg => arg[0].value === 'tape'
+	})
+	.filter(p => p.value.arguments.length === 1)
+	.forEach(p => {
+		p.node.arguments[0].value = 'ava';
+		testFunctionName = p.parentPath.value.id.name;
+	});
+
+	ast.find(j.ImportDeclaration, {
+		source: {
+			type: 'Literal',
+			value: 'tape'
+		}
+	})
+	.forEach(p => {
+		p.node.source.value = 'ava';
+		testFunctionName = p.value.specifiers[0].local.name;
+	});
+
+	return testFunctionName;
+}
+
+export default function tapeToAva(fileInfo, api) {
+	const j = api.jscodeshift;
+	const ast = j(fileInfo.source);
+
+	const testFunctionName = updateTapeRequireAndImport(j, ast);
+
+	if (!testFunctionName) {
+		// No Tape require/import were found
+		return fileInfo.source;
+	}
+
+	const warnings = new Set();
+	function logWarning(msg, node) {
+		if (warnings.has(msg)) {
+			return;
+		}
+		console.warn(`tape-to-ava warning: (${fileInfo.path} line ${node.value.loc.start.line}) ${msg}`);
+		warnings.add(msg);
+	}
+
+	const transforms = [
+		function detectUnsupportedNaming() {
+			// Currently we only support "t" as the test argument name
+			const validateTestArgument = p => {
+				const lastArg = p.value.arguments[p.value.arguments.length - 1];
+				if (lastArg && lastArg.params && lastArg.params[0]) {
+					const lastArgName = lastArg.params[0].name;
+					if (lastArgName !== 't') {
+						logWarning(`argument to test function should be named "t" not "${lastArgName}"`, p);
+					}
+				}
+			};
+
+			ast.find(j.CallExpression, {
+				callee: {
+					object: {name: testFunctionName}
+				}
+			})
+			.forEach(validateTestArgument);
+
+			ast.find(j.CallExpression, {
+				callee: {name: testFunctionName}
+			})
+			.forEach(validateTestArgument);
+		},
+
+		function detectUnsupportedFeatures() {
+			ast.find(j.CallExpression, {
+				callee: {
+					object: {name: 't'},
+					property: ({name}) => unsupportedTestFunctions.has(name)
+				}
+			})
+			.forEach(p => {
+				const propertyName = p.value.callee.property.name;
+				if (propertyName.toLowerCase().indexOf('looseequal') >= 0) {
+					logWarning(`"${propertyName}" is not supported. Try the stricter "deepEqual" or "notDeepEqual"`, p);
+				} else {
+					logWarning(`"${propertyName}" is not supported`, p);
+				}
+			});
+
+			ast.find(j.CallExpression, {
+				callee: {
+					object: {name: testFunctionName},
+					property: {name: 'createStream'}
+				}
+			})
+			.forEach(p => {
+				logWarning('"createStream" is not supported', p);
+			});
+		},
+
+		function updateAssertions() {
+			ast.find(j.CallExpression, {
+				callee: {
+					object: {name: 't'},
+					property: ({name}) => Object.keys(tapeToAvaAsserts).indexOf(name) >= 0
+				}
+			})
+			.forEach(p => {
+				const {property} = p.node.callee;
+				property.name = tapeToAvaAsserts[property.name];
+			});
+		},
+
+		function testOptionArgument() {
+			// Convert Tape option parameters, test([name], [opts], cb)
+			ast.find(j.CallExpression, {
+				callee: {name: testFunctionName}
+			}).forEach(p => {
+				p.value.arguments.forEach(a => {
+					if (a.type === 'ObjectExpression') {
+						a.properties.forEach(tapeOption => {
+							const tapeOptionKey = tapeOption.key.name;
+							const tapeOptionValue = tapeOption.value.value;
+							if (tapeOptionKey === 'skip' && tapeOptionValue === true) {
+								p.value.callee.name += '.cb.serial.skip';
+							}
+
+							if (tapeOptionKey === 'timeout') {
+								logWarning('"timeout" option is not supported', p);
+							}
+						});
+
+						p.value.arguments = p.value.arguments.filter(pa => pa.type !== 'ObjectExpression');
+					}
+				});
+			});
+		},
+
+		function updateTapeComments() {
+			ast.find(j.CallExpression, {
+				callee: {
+					object: {name: 't'},
+					property: {name: 'comment'}
+				}
+			})
+			.forEach(p => {
+				p.node.callee = 'console.log';
+			});
+		},
+
+		function updateThrows() {
+			// The semantics of t.throws(fn, expected, msg) is different.
+			// - Tape: if `expected` is a string, it is set to msg
+			// - AVA: if `expected` is a string it is transformed to a function
+			ast.find(j.CallExpression, {
+				callee: {
+					object: {name: 't'},
+					property: {name: 'throws'}
+				},
+				arguments: arg => arg.length === 2 && arg[1].type === 'Literal' && typeof arg[1].value === 'string'
+			})
+			.forEach(p => {
+				const [fn, msg] = p.node.arguments;
+				p.node.arguments = [fn, j.literal(null), msg];
+			});
+		},
+
+		function updateTapeOnFinish() {
+			ast.find(j.CallExpression, {
+				callee: {
+					object: {name: testFunctionName},
+					property: {name: 'onFinish'}
+				}
+			})
+			.forEach(p => {
+				p.node.callee.property.name = 'after.always';
+			});
+		},
+
+		function rewriteTestCallExpression() {
+			// To be on the safe side we rewrite the test(...) function to
+			// either test.cb.serial(...) or test.serial(...)
+			//
+			// - .serial as Tape runs all tests serially
+			// - .cb for tests containing t.end, as we cannot detect if the
+			//   test have any asynchronicity.
+			ast.find(j.CallExpression, {
+				callee: {name: 'test'}
+			}).forEach(p => {
+				// TODO: if t.end is in the scope of the test function we could
+				// remove it and not use cb style.
+				const containsEndFunction = j(p).find(j.CallExpression, {
+					callee: {
+						object: {name: 't'},
+						property: {name: 'end'}
+					}
+				}).size() > 0;
+
+				const newTestFunction = containsEndFunction ? 'cb.serial' : 'serial';
+
+				p.node.callee = j.memberExpression(
+					j.identifier('test'),
+					j.identifier(newTestFunction)
+				);
+			});
+		}
+	];
+
+	transforms.forEach(t => t());
+
+	// As Recast is not preserving original quoting, we try to detect it,
+	// and default to something sane.
+	// See https://github.com/benjamn/recast/issues/171
+	// and https://github.com/facebook/jscodeshift/issues/143
+	const quote = detectQuoteStyle(j, ast) || 'single';
+	return ast.toSource({quote});
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "email": "james@talmage.io",
     "url": "github.com/jamestalmage"
   },
-  "bin": "cli.js",
+  "bin": {
+    "ava-codemods": "ava-codemods.js",
+    "tape-to-ava": "tape-to-ava.js"
+  },
   "engines": {
     "node": ">=4"
   },
@@ -17,8 +20,9 @@
     "test": "xo && ava"
   },
   "files": [
-    "cli.js",
+    "ava-codemods.js",
     "cli-utils.js",
+    "tape-to-ava.js",
     "codemods.json",
     "lib"
   ],
@@ -39,7 +43,6 @@
     "inquirer": "^1.0.2",
     "is-git-clean": "^1.1.0",
     "jscodeshift": "^0.3.19",
-    "lodash.assign": "^4.0.7",
     "lodash.flatten": "^4.1.1",
     "lodash.uniq": "^4.2.1",
     "meow": "^3.7.0",
@@ -62,8 +65,9 @@
   "babel": {
     "only": [
       "lib/**",
-      "cli.js",
+      "ava-codemods.js",
       "cli-utils.js",
+      "tape-to-ava.js",
       "test/_helpers.js"
     ],
     "sourceMaps": "inline"

--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,12 @@
 # ava-codemods [![Build Status](https://travis-ci.org/avajs/ava-codemods.svg?branch=master)](https://travis-ci.org/avajs/ava-codemods)
 
-> Codemods for [AVA](https://ava.li) that simplifies upgrading to newer versions
+> Codemods for [AVA](https://ava.li) that simplifies upgrading to newer versions and migrating to AVA
 
 <img src="screenshot.gif" width="440" align="right">
 
 Codemods are small programs that help you automate changes to your codebase. Think of them as search and replace on steroids.
 
-This module contains a set of codemods that enable you to upgrade your code between various AVA releases. It is maintained by the AVA team, and will be updated anytime we introduce breaking API changes. We plan to eventually introduce codemods that allow you to switch from other popular test runners like `mocha` and `tap`.
+This module contains a set of codemods that enable you to upgrade your code between various AVA releases and migrate from existing test runners to AVA. It is maintained by the AVA team, and will be updated anytime we introduce breaking API changes.
 
 
 ## Install
@@ -15,8 +15,33 @@ This module contains a set of codemods that enable you to upgrade your code betw
 $ npm install --global ava-codemods
 ```
 
+This installs two binaries `ava-codemods` and `tape-to-ava`.
 
-## Usage
+
+## Migrating to AVA
+
+Currently we support migrating from [tape](https://github.com/substack/tape) to AVA.
+
+```
+$ tape-to-ava --help
+
+	Usage
+	  $ tape-to-ava <path> [options]
+
+	path	Files or directory to transform. Can be a glob like src/**.test.js
+
+	Options
+	  --force, -f	Bypass Git safety checks and forcibly run codemods
+	  --dry, -d		Dry run (no changes are made to files)
+	  --parser		The parser to use for parsing your source files (babel | babylon | flow)  [babel]
+```
+
+To transform all test files in a directory run `tape-to-ava mySrcFolder` in your terminal. Only files requiring or importing tape will be transformed. Notice the console output for errors, manual intervention might be required.
+
+As we cannot statically determine if your sequential tape tests are able to run in parallel, all tests are transformed into `test.serial`. To speed up the AVA test execution you can remove `.serial` where applicable.
+
+
+## Upgrade AVA version
 
 ```
 $ ava-codemods --help
@@ -37,13 +62,13 @@ Simply run `ava-codemods` in your terminal and answer a few questions. You can p
 Ensure you have a backup of your tests or commit the latest changes before running this.
 
 
-## Supported codemods
+### Supported codemods
 
-### Upgrading to 0.17.x
+#### Upgrading to 0.17.x
 
 - Renaming `t.error()` to `t.ifError()`
 
-### Upgrading to 0.14.x
+#### Upgrading to 0.14.x
 
 - Renaming `t.ok()` to `t.truthy()`
 - Renaming `t.notOk()` to `t.falsy()`

--- a/tape-to-ava.js
+++ b/tape-to-ava.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import path from 'path';
+import execa from 'execa';
+import meow from 'meow';
+import updateNotifier from 'update-notifier';
+import * as utils from './cli-utils';
+
+const PATH_TRANFORMER = path.join(__dirname, 'lib', 'tape.js');
+
+function executeTransformation(files, flags) {
+	const spawnOptions = {
+		stdio: 'inherit',
+		stripEof: false
+	};
+
+	const args = ['-t', PATH_TRANFORMER].concat(files);
+	if (flags.dry) {
+		args.push('--dry');
+	}
+	if (['babel', 'babylon', 'flow'].indexOf(flags.parser) >= 0) {
+		args.push('--parser', flags.parser);
+	}
+
+	console.log(`Executing command: jscodeshift ${args.join(' ')}`);
+
+	const result = execa.sync('jscodeshift', args, spawnOptions);
+	if (result.error) {
+		throw result.error;
+	}
+}
+
+const cli = meow(
+	{
+		description: 'Codemod to change test runner from Tape to AVA',
+		help: `
+	Usage
+	  $ tape-to-ava <path> [options]
+
+	path	Files or directory to transform. Can be a glob like src/**.test.js
+
+	Options
+	  --force, -f	Bypass Git safety checks and forcibly run codemods
+	  --dry, -d	Dry run (no changes are made to files)
+	  --parser	The parser to use for parsing your source files (babel | babylon | flow)  [babel]
+	`
+	},
+	{
+		boolean: ['force', 'dry'],
+		string: ['_'],
+		alias: {
+			f: 'force',
+			h: 'help',
+			d: 'dry'
+		}
+	}
+);
+
+updateNotifier({pkg: cli.pkg}).notify();
+
+const files = cli.input;
+if (files.length === 0) {
+	cli.showHelp();
+} else {
+	if (!utils.checkGitStatus(cli.flags.force)) {
+		process.exit(1);
+	}
+	executeTransformation(files, cli.flags);
+}

--- a/test/tape.js
+++ b/test/tape.js
@@ -1,0 +1,307 @@
+import test from 'ava';
+
+import jscodeshift from 'jscodeshift';
+import testPlugin from 'jscodeshift-ava-tester';
+
+import plugin from '../lib/tape';
+import {wrapPlugin} from './_helpers';
+
+const {testChanged} = testPlugin(jscodeshift, test, plugin);
+const wrapped = wrapPlugin(plugin);
+
+test.beforeEach(t => {
+	t.context.originalConsoleWarn = console.warn;
+	t.context.consoleWarnings = [];
+	console.warn = v => t.context.consoleWarnings.push(v);
+});
+
+test.afterEach(t => {
+	console.warn = t.context.originalConsoleWarn;
+});
+
+testChanged('does not touch code without tape require/import',
+`
+const test = require("testlib");
+test(t => {
+	t.notOk(1);
+});`,
+`
+const test = require("testlib");
+test(t => {
+	t.notOk(1);
+});`
+);
+
+testChanged('CommonJs requires',
+`const test = require('tape');`,
+`const test = require('ava');`
+);
+
+testChanged('ES2015 imports',
+`import test from 'tape';`,
+`import test from 'ava';`
+);
+
+testChanged('maps assertions and comments',
+`
+import test from 'tape';
+test(t => {
+	t.fail('msg');
+	t.pass('msg');
+	t.ok(1, 'msg');
+	t.true(1, 'msg');
+	t.assert(1, 2, 'msg');
+	t.notOk(1, 'msg');
+	t.false(1, 'msg');
+	t.notok(1, 'msg');
+	t.error(1, 'msg');
+	t.ifErr(1, 'msg');
+	t.iferror(1, 'msg');
+	t.equal(1, 2, 'msg');
+	t.equals(1, 2, 'msg');
+	t.isEqual(1, 2, 'msg');
+	t.strictEqual(1, 2, 'msg');
+	t.strictEquals(1, 2, 'msg');
+	t.notEqual(1, 2, 'msg');
+	t.notStrictEqual(1, 2, 'msg');
+	t.notStrictEquals(1, 2, 'msg');
+	t.isNotEqual(1, 2, 'msg');
+	t.doesNotEqual(1, 2, 'msg');
+	t.isInequal(1, 2, 'msg');
+	t.deepEqual(1, 2, 'msg');
+	t.isEquivalent(1, 2, 'msg');
+	t.same(1, 2, 'msg');
+	t.notDeepEqual(1, 2, 'msg');
+	t.notEquivalent(1, 2, 'msg');
+	t.notDeeply(1, 2, 'msg');
+	t.notSame(1, 2, 'msg');
+	t.isNotDeepEqual(1, 2, 'msg');
+	t.isNotEquivalent(1, 2, 'msg');
+	t.isInequivalent(1, 2, 'msg');
+	t.skip('msg');
+	t.throws(1, 'msg');
+	t.doesNotThrow(1, 'msg');
+	t.comment('this is a comment...');
+});
+`,
+`
+import test from 'ava';
+test.serial(t => {
+	t.fail('msg');
+	t.pass('msg');
+	t.truthy(1, 'msg');
+	t.truthy(1, 'msg');
+	t.truthy(1, 2, 'msg');
+	t.falsy(1, 'msg');
+	t.falsy(1, 'msg');
+	t.falsy(1, 'msg');
+	t.ifError(1, 'msg');
+	t.ifError(1, 'msg');
+	t.ifError(1, 'msg');
+	t.is(1, 2, 'msg');
+	t.is(1, 2, 'msg');
+	t.is(1, 2, 'msg');
+	t.is(1, 2, 'msg');
+	t.is(1, 2, 'msg');
+	t.not(1, 2, 'msg');
+	t.not(1, 2, 'msg');
+	t.not(1, 2, 'msg');
+	t.not(1, 2, 'msg');
+	t.not(1, 2, 'msg');
+	t.not(1, 2, 'msg');
+	t.deepEqual(1, 2, 'msg');
+	t.deepEqual(1, 2, 'msg');
+	t.deepEqual(1, 2, 'msg');
+	t.notDeepEqual(1, 2, 'msg');
+	t.notDeepEqual(1, 2, 'msg');
+	t.notDeepEqual(1, 2, 'msg');
+	t.notDeepEqual(1, 2, 'msg');
+	t.notDeepEqual(1, 2, 'msg');
+	t.notDeepEqual(1, 2, 'msg');
+	t.notDeepEqual(1, 2, 'msg');
+	t.skip('msg');
+	t.throws(1, null, 'msg');
+	t.notThrows(1, 'msg');
+	console.log('this is a comment...');
+});
+`);
+
+testChanged('preserves quote style',
+`
+import test from "tape";
+test("mytest", t => {
+	t.pass("msg");
+});
+`,
+`
+import test from "ava";
+test.serial("mytest", t => {
+	t.pass("msg");
+});
+`
+);
+
+testChanged('test options: removes',
+`
+import test from 'tape';
+test('mytest', {objectPrintDepth: 4, skip: false}, t => {
+	t.pass('msg');
+});
+`,
+`
+import test from 'ava';
+test.serial('mytest', t => {
+	t.pass('msg');
+});
+`
+);
+
+testChanged('test options: skip',
+`
+import test from 'tape';
+test('mytest', {objectPrintDepth: 4, skip: true}, t => {
+	t.pass('msg');
+});
+`,
+`
+import test from 'ava';
+test.cb.serial.skip('mytest', t => {
+	t.pass('msg');
+});
+`
+);
+
+testChanged('t.end converts to callback test',
+`
+import test from 'tape';
+test('mytest', t => {
+	t.equal(1, 1);
+	setTimeout(() => {
+		t.end();
+	}, 500);
+});
+`,
+`
+import test from 'ava';
+test.cb.serial('mytest', t => {
+	t.is(1, 1);
+	setTimeout(() => {
+		t.end();
+	}, 500);
+});
+`
+);
+
+testChanged('test.onFinish',
+`
+import myTestFunc from 'tape';
+myTestFunc.onFinish(() => {});
+`,
+`
+import myTestFunc from 'ava';
+myTestFunc.after.always(() => {});
+`);
+
+testChanged('t.throws',
+`
+import test from 'tape';
+test(t => {
+	t.throws(myfunc, 'should not throw');
+	t.throws(myfunc, 'xxx', 'should not throw');
+	t.throws(myfunc, /err_reg_exp/i);
+	t.throws(myfunc, /err_reg_exp/i, 'should not throw');
+});
+`,
+`
+import test from 'ava';
+test.serial(t => {
+	t.throws(myfunc, null, 'should not throw');
+	t.throws(myfunc, 'xxx', 'should not throw');
+	t.throws(myfunc, /err_reg_exp/i);
+	t.throws(myfunc, /err_reg_exp/i, 'should not throw');
+});
+`
+);
+
+test.serial('not supported warnings', t => {
+	wrapped(`
+		import test from 'tape';
+		test.createStream(() => {});
+		test.createStream(() => {}); // only logs once
+	`);
+	t.is(t.context.consoleWarnings.length, 1, 'one warnings logged');
+	t.is(
+		t.context.consoleWarnings[0],
+		'tape-to-ava warning: (test.js line 3) "createStream" is not supported',
+	);
+});
+
+test.serial('not supported: timeoutAfter', t => {
+	wrapped(`
+		import test from 'tape';
+		test(t => {
+			t.timeoutAfter(100);
+		});
+	`);
+	t.is(t.context.consoleWarnings.length, 1, 'one warnings logged');
+	t.is(
+		t.context.consoleWarnings[0],
+		'tape-to-ava warning: (test.js line 4) "timeoutAfter" is not supported',
+	);
+});
+
+test.serial('not supported: looseEquals', t => {
+	wrapped(`
+		import test from 'tape';
+		test(t => {
+			t.looseEquals({}, {});
+		});
+	`);
+	t.is(t.context.consoleWarnings.length, 1, 'one warnings logged');
+	t.is(
+		t.context.consoleWarnings[0],
+		'tape-to-ava warning: (test.js line 4) "looseEquals" is not supported. Try the stricter "deepEqual" or "notDeepEqual"',
+	);
+});
+
+test.serial('not supported: timeout option', t => {
+	wrapped(`
+		import test from 'tape';
+		test({timeout: 42}, t => {
+			t.pass();
+		});
+	`);
+	t.is(t.context.consoleWarnings.length, 1, 'one warnings logged');
+	t.is(
+		t.context.consoleWarnings[0],
+		'tape-to-ava warning: (test.js line 3) "timeout" option is not supported'
+	);
+});
+
+test.serial('not supported: non standard argument for test', t => {
+	wrapped(`
+		import test from 'tape';
+		test(x => {
+			x.pass();
+		});
+	`);
+	t.is(t.context.consoleWarnings.length, 1, 'one warnings logged');
+	t.is(
+		t.context.consoleWarnings[0],
+		'tape-to-ava warning: (test.js line 3) argument to test function should be named "t" not "x"'
+	);
+});
+
+test.serial('not supported: non standard argument for test.skip', t => {
+	wrapped(`
+		import test from 'tape';
+		test.skip(function(y) {
+			y.pass();
+		});
+	`);
+	t.is(t.context.consoleWarnings.length, 1, 'one warnings logged');
+	t.is(
+		t.context.consoleWarnings[0],
+		'tape-to-ava warning: (test.js line 3) argument to test function should be named "t" not "y"'
+	);
+});


### PR DESCRIPTION
Please have a look @sindresorhus @DrewML 

For background, see https://github.com/avajs/ava-codemods/issues/5
#### Missing
- [x] Update README
- [x] review of CLI and tranformer
#### Later
- if `t.end` is in the scope of the test function, we could remove it and not use cb style
- rename first param in test callback function, if it is not `t` (and replace usage of identifier in block). Note: currently we just fail with a nice error message instead.

Closes #5 
