### PR TITLE
Use `jscodeshift-ava-tester` to create codemod tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "ava": "^0.16.0",
     "babel": "^5.8.38",
+    "jscodeshift-ava-tester": "^1.0.0",
     "xo": "^0.16.0"
   },
   "ava": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "ava": "^0.16.0",
     "babel": "^5.8.38",
-    "jscodeshift-ava-tester": "^1.0.0",
+    "jscodeshift-ava-tester": "^1.1.0",
     "xo": "^0.16.0"
   },
   "ava": {

--- a/test/error-to-iferror.js
+++ b/test/error-to-iferror.js
@@ -5,5 +5,5 @@ import plugin from '../lib/error-to-iferror';
 
 const {testChanged, testUnchanged} = testPlugin(jscodeshift, test, plugin);
 
-testChanged('t.error(foo, bar)', 't.ifError(foo, bar)');
-testUnchanged('t.ifError(foo, bar)');
+testChanged('error >> ifError', 't.error(foo, bar)', 't.ifError(foo, bar)');
+testUnchanged('unchanged ifError', 't.ifError(foo, bar)');

--- a/test/error-to-iferror.js
+++ b/test/error-to-iferror.js
@@ -1,11 +1,9 @@
 import test from 'ava';
+import jscodeshift from 'jscodeshift';
+import testPlugin from 'jscodeshift-ava-tester';
 import plugin from '../lib/error-to-iferror';
-import {wrapPlugin} from './_helpers';
 
-const wrapped = wrapPlugin(plugin);
+const {testChanged, testUnchanged} = testPlugin(jscodeshift, test, plugin);
 
-function tester(t, input, expected) {
-	t.is(wrapped(input), expected);
-}
-
-test('error >> ifError', tester, 't.error(foo, bar)', 't.ifError(foo, bar)');
+testChanged('t.error(foo, bar)', 't.ifError(foo, bar)');
+testUnchanged('t.ifError(foo, bar)');

--- a/test/ok-to-truthy.js
+++ b/test/ok-to-truthy.js
@@ -5,7 +5,7 @@ import plugin from '../lib/ok-to-truthy';
 
 const {testChanged, testUnchanged} = testPlugin(jscodeshift, test, plugin);
 
-testChanged('t.ok(foo, bar)', 't.truthy(foo, bar)');
-testChanged('t.notOk(foo, bar)', 't.falsy(foo, bar)');
-testUnchanged('t.truthy(foo, bar)');
-testUnchanged('t.falsy(foo, bar)');
+testChanged('ok >> truthy', 't.ok(foo, bar)', 't.truthy(foo, bar)');
+testChanged('notOk >> falsy', 't.notOk(foo, bar)', 't.falsy(foo, bar)');
+testUnchanged('unchanged truthy', 't.truthy(foo, bar)');
+testUnchanged('unchanged falsy', 't.falsy(foo, bar)');

--- a/test/ok-to-truthy.js
+++ b/test/ok-to-truthy.js
@@ -1,12 +1,11 @@
 import test from 'ava';
+import jscodeshift from 'jscodeshift';
+import testPlugin from 'jscodeshift-ava-tester';
 import plugin from '../lib/ok-to-truthy';
-import {wrapPlugin} from './_helpers';
 
-const wrapped = wrapPlugin(plugin);
+const {testChanged, testUnchanged} = testPlugin(jscodeshift, test, plugin);
 
-function tester(t, input, expected) {
-	t.is(wrapped(input), expected);
-}
-
-test('ok >> truthy', tester, 't.ok(foo, bar)', 't.truthy(foo, bar)');
-test('notOk >> falsy', tester, 't.notOk(foo, bar)', 't.falsy(foo, bar)');
+testChanged('t.ok(foo, bar)', 't.truthy(foo, bar)');
+testChanged('t.notOk(foo, bar)', 't.falsy(foo, bar)');
+testUnchanged('t.truthy(foo, bar)');
+testUnchanged('t.falsy(foo, bar)');

--- a/test/same-to-deep-equal.js
+++ b/test/same-to-deep-equal.js
@@ -1,20 +1,25 @@
 import test from 'ava';
+import jscodeshift from 'jscodeshift';
+import testPlugin from 'jscodeshift-ava-tester';
 import plugin from '../lib/same-to-deep-equal';
-import {wrapPlugin} from './_helpers';
 
-const wrapped = wrapPlugin(plugin);
+const {testChanged, testUnchanged} = testPlugin(jscodeshift, test, plugin);
 
-function tester(t, input, expected) {
-	t.is(wrapped(input), expected);
-}
-
-test('same >> deepEqual', tester, 't.same(foo, bar)', 't.deepEqual(foo, bar)');
-test('notSame >> notDeepEqual', tester, 't.notSame(foo, bar)', 't.notDeepEqual(foo, bar)');
-test('full test expression with same >> deepEqual', tester, `
+testChanged('t.same(foo, bar)', 't.deepEqual(foo, bar)');
+testChanged('t.notSame(foo, bar)', 't.notDeepEqual(foo, bar)');
+testChanged(`
 test(t => {
 		t.same(fn.sync('1.tmp', {cwd: t.context.tmp}), [path.join(t.context.tmp, '1.tmp')]);
 });
 `, `
+test(t => {
+		t.deepEqual(fn.sync('1.tmp', {cwd: t.context.tmp}), [path.join(t.context.tmp, '1.tmp')]);
+});
+`);
+
+testUnchanged('t.deepEqual(foo, bar)');
+testUnchanged('t.notDeepEqual(foo, bar)');
+testUnchanged(`
 test(t => {
 		t.deepEqual(fn.sync('1.tmp', {cwd: t.context.tmp}), [path.join(t.context.tmp, '1.tmp')]);
 });

--- a/test/same-to-deep-equal.js
+++ b/test/same-to-deep-equal.js
@@ -5,9 +5,9 @@ import plugin from '../lib/same-to-deep-equal';
 
 const {testChanged, testUnchanged} = testPlugin(jscodeshift, test, plugin);
 
-testChanged('t.same(foo, bar)', 't.deepEqual(foo, bar)');
-testChanged('t.notSame(foo, bar)', 't.notDeepEqual(foo, bar)');
-testChanged(`
+testChanged('same >> deepEqual', 't.same(foo, bar)', 't.deepEqual(foo, bar)');
+testChanged('notSame >> notDeepEqual', 't.notSame(foo, bar)', 't.notDeepEqual(foo, bar)');
+testChanged('full test expression with same >> deepEqual', `
 test(t => {
 		t.same(fn.sync('1.tmp', {cwd: t.context.tmp}), [path.join(t.context.tmp, '1.tmp')]);
 });
@@ -17,9 +17,9 @@ test(t => {
 });
 `);
 
-testUnchanged('t.deepEqual(foo, bar)');
-testUnchanged('t.notDeepEqual(foo, bar)');
-testUnchanged(`
+testUnchanged('unchanged deepEqual', 't.deepEqual(foo, bar)');
+testUnchanged('unchanged notDeepEqual', 't.notDeepEqual(foo, bar)');
+testUnchanged('unchanged full test expression with deepEqual', `
 test(t => {
 		t.deepEqual(fn.sync('1.tmp', {cwd: t.context.tmp}), [path.join(t.context.tmp, '1.tmp')]);
 });


### PR DESCRIPTION
I wrote lodash-codemods, where I used the same tool to write tests as in this repo. I have now created a new package that exports this jscodeshift wrapper logic.

In the meantime, @DrewML came along and added titles to the tests here, which I think is pretty neat, but for which my tool doesn't offer support, though it should be easy to add. What do you guys think of this, and should I allow an optional title in my test creators?

(I've added a few simple tests too. Maybe I shouldn't have, but they were so easy that I couldn't resist...)
