### PR TITLE
Allow `package.json` to be dirty

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -53,7 +53,7 @@ updateNotifier({pkg: cli.pkg}).notify();
 let clean = false;
 let errorMessage = 'Unable to determine if git directory is clean';
 try {
-	clean = isGitClean.sync();
+	clean = isGitClean.sync(process.cwd(), {files: ['!package.json']});
 	errorMessage = 'Git directory is not clean';
 } catch (err) {}
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "execa": "^0.4.0",
     "globby": "^6.0.0",
     "inquirer": "^1.0.2",
-    "is-git-clean": "^1.0.0",
+    "is-git-clean": "^1.1.0",
     "jscodeshift": "^0.3.19",
     "lodash.assign": "^4.0.7",
     "lodash.flatten": "^4.1.1",


### PR DESCRIPTION
Fixes #14.

Just needs a new `is-git-clean` version to be published—the PR has been merged.
