### PR TITLE
Reverted import to require. Fixes tape-to-ava

### DIFF
--- a/lib/tape.js
+++ b/lib/tape.js
@@ -112,7 +112,7 @@ function updateTapeRequireAndImport(j, ast) {
 	return testFunctionName;
 }
 
-export default function tapeToAva(fileInfo, api) {
+module.exports = function tapeToAva(fileInfo, api) {
 	const j = api.jscodeshift;
 	const ast = j(fileInfo.source);
 
@@ -301,4 +301,4 @@ export default function tapeToAva(fileInfo, api) {
 	// and https://github.com/facebook/jscodeshift/issues/143
 	const quote = detectQuoteStyle(j, ast) || 'single';
 	return ast.toSource({quote});
-}
+};


### PR DESCRIPTION
`tape-to-ava` doesn't work with es6 imports, so I reverted this one as well.